### PR TITLE
Fix four leaf clover icon types

### DIFF
--- a/src/components/Icons/ssr/FourLeafClover.tsx
+++ b/src/components/Icons/ssr/FourLeafClover.tsx
@@ -1,7 +1,7 @@
 import { forwardRef } from "react";
+import type { CustomIcon } from "../../../utils";
 import { FourLeafCloverWeights } from "../defs";
 import { CustomIconBase } from "../lib";
-import type { CustomIcon } from "../types";
 
 const FourLeafCloverIcon: CustomIcon = forwardRef((props, ref) => (
 	<CustomIconBase ref={ref} {...props} weights={FourLeafCloverWeights} />


### PR DESCRIPTION
This pull request fixes the four leaf clover icon types by importing the correct type and removing an unnecessary import statement.