### PR TITLE
SUI-43: Add DialogTitle subcomponent

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,4 +1,5 @@
 import { Text } from "@components";
+import type { Icon } from "@phosphor-icons/react";
 import type { CustomIcon } from "@utils";
 import { type VariantProps, cva } from "class-variance-authority";
 import { type ComponentProps, forwardRef } from "react";
@@ -7,8 +8,8 @@ import { twMerge } from "tailwind-merge";
 type ButtonProps = VariantProps<typeof buttonStyles> &
 	ComponentProps<"button"> & {
 		label?: string;
-		rightIcon?: CustomIcon;
-		leftIcon?: CustomIcon;
+		rightIcon?: Icon | CustomIcon;
+		leftIcon?: Icon | CustomIcon;
 	};
 
 const buttonStyles = cva(
@@ -56,8 +57,8 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 			size = "sm",
 			className,
 			label,
-			rightIcon: RightIcon,
 			leftIcon: LeftIcon,
+			rightIcon: RightIcon,
 			...props
 		},
 		ref,
@@ -75,9 +76,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 			{...props}
 		>
 			{LeftIcon && (
-				<div className="">
-					<LeftIcon size={IconSizes[size || "sm"]} alt="left button icon" />
-				</div>
+				<LeftIcon size={IconSizes[size || "sm"]} alt="left button icon" />
 			)}
 			{label && (
 				<Text size={size === "sm" ? 14 : 18} className="group-hover:px-1">
@@ -85,9 +84,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 				</Text>
 			)}
 			{RightIcon && (
-				<div className="">
-					<RightIcon size={IconSizes[size || "sm"]} alt="right button icon" />
-				</div>
+				<RightIcon size={IconSizes[size || "sm"]} alt="right button icon" />
 			)}
 		</button>
 	),

--- a/src/components/Dialog/DialogTitle.tsx
+++ b/src/components/Dialog/DialogTitle.tsx
@@ -1,0 +1,38 @@
+import { Button, CloseIcon, Text } from "@components";
+import type { Icon } from "@phosphor-icons/react";
+import type { CustomIcon } from "@utils";
+import { type ComponentProps, forwardRef } from "react";
+
+type DialogTitleProps = {
+	icon?: Icon | CustomIcon;
+	title: string;
+	onClose?: () => void;
+} & ComponentProps<"div">;
+
+const DialogTitle = forwardRef<HTMLDivElement, DialogTitleProps>(
+	({ icon: Icon, title, onClose }, ref) => (
+		<div
+			className="flex justify-between items-center"
+			ref={ref}
+			role="complementary"
+		>
+			<div className="flex gap-4 items-center text-black-100">
+				{Icon && <Icon size={48} alt={title} weight="regular" />}
+				<Text as="p" size={48} semibold>
+					{title}
+				</Text>
+			</div>
+			{onClose && (
+				<Button
+					onClick={onClose}
+					size="md"
+					variant="gray"
+					leftIcon={CloseIcon}
+				/>
+			)}
+		</div>
+	),
+);
+
+DialogTitle.displayName = "DialogTitle";
+export { DialogTitle };

--- a/src/components/Dialog/index.ts
+++ b/src/components/Dialog/index.ts
@@ -1,0 +1,1 @@
+export * from "./DialogTitle";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,6 +2,7 @@ export * from "./Avatar";
 export * from "./Badge";
 export * from "./Button";
 export * from "./Card";
+export * from "./Dialog";
 export * from "./DropDown";
 export * from "./Icons";
 export * from "./Input";

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -2,7 +2,7 @@ import { ArrowLineDownIcon, Button, FourLeafCloverIcon } from "@components";
 import { SIZES } from "@constants";
 import { buttonVariantControl, iconControl, sizeControl } from "@mocks";
 import type { Meta, StoryObj } from "@storybook/react";
-import { expect, fn, within } from "@storybook/test";
+import { expect, fn, userEvent, within } from "@storybook/test";
 
 const clickHandler = fn();
 
@@ -48,10 +48,11 @@ export const Borderless: Story = {
 	args: {
 		variant: "borderless",
 	},
-	play: ({ canvasElement }) => {
+	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const button = canvas.getByRole("button");
-		button.click();
+
+		await userEvent.click(button);
 
 		expect(clickHandler).toHaveBeenCalledOnce();
 		expect(button).toHaveClass("bg-transparent");
@@ -179,15 +180,13 @@ export const Disabled: Story = {
 		variant: "filled",
 		disabled: true,
 	},
-	play: ({ canvasElement }) => {
+	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const button = canvas.getByRole("button");
-		button.click();
+
+		await userEvent.click(button);
 
 		expect(clickHandler).not.toHaveBeenCalledOnce();
-		expect(button).toHaveStyle(
-			"background-color: rgba(28, 28, 28, 0.05); color: rgba(28, 28, 28, 0.1); cursor: not-allowed;",
-		);
 	},
 };
 

--- a/src/stories/DialogTitle.stories.tsx
+++ b/src/stories/DialogTitle.stories.tsx
@@ -1,0 +1,77 @@
+import { AddIcon, DialogTitle } from "@components";
+import { iconControl } from "@mocks";
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect, fn, userEvent, within } from "@storybook/test";
+
+const testTitle = "Title";
+const testCloseFn = fn();
+
+const meta = {
+	title: "Base Components/Dialog/Dialog Title",
+	component: DialogTitle,
+	parameters: {
+		// Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
+		layout: "centered",
+	},
+	// This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+	tags: ["autodocs"],
+	// More on argTypes: https://storybook.js.org/docs/api/argtypes
+	argTypes: {
+		icon: iconControl,
+		onClose: {
+			control: null,
+			description: "Function to close the dialog",
+		},
+	},
+	// Use `fn` to spy on the onClick arg, which will appear in the actions panel once invoked: https://storybook.js.org/docs/essentials/actions#action-args
+	args: {
+		icon: undefined,
+		title: testTitle,
+	},
+	decorators: [
+		(Story) => (
+			<div className="min-w-80">
+				<Story />
+			</div>
+		),
+	],
+} satisfies Meta<typeof DialogTitle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const BasicDialogTitle: Story = {
+	args: {},
+	play: ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const DialogTitle = canvas.getByRole("complementary");
+
+		expect(DialogTitle).toHaveTextContent(testTitle);
+	},
+};
+
+export const DialogWithIcon: Story = {
+	args: {
+		icon: AddIcon,
+	},
+	play: ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const Icon = canvas.getByTitle(testTitle);
+
+		expect(Icon).toBeInTheDocument();
+	},
+};
+
+export const DialogTitleWithCloseButton: Story = {
+	args: {
+		onClose: testCloseFn,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const CloseButton = canvas.getByRole("button");
+
+		await userEvent.click(CloseButton);
+
+		expect(testCloseFn).toHaveBeenCalled();
+	},
+};

--- a/src/stories/mocks/index.tsx
+++ b/src/stories/mocks/index.tsx
@@ -12,7 +12,8 @@ import {
 	STATUSES,
 	STATUSES_EXPANDED,
 } from "@constants";
-import { getInitials } from "@utils";
+import type { Icon } from "@phosphor-icons/react";
+import { type CustomIcon, getInitials } from "@utils";
 
 export const testStatus = "12";
 export const testUserName = "John Doe";
@@ -44,7 +45,11 @@ export const imgSourceControl = {
 	options: [...Object.values(imageSrcMocks), null],
 };
 
-export const iconControl = {
+export const iconControl: {
+	control: "radio";
+	options: (string | undefined)[];
+	mapping: Record<string, Icon | CustomIcon | undefined>;
+} = {
 	control: "radio",
 	options: [
 		"Nothing",


### PR DESCRIPTION
This pull request adds a new subcomponent called DialogTitle to the components folder. The DialogTitle component is used to display a title and an optional icon in a dialog. It also includes a close button that can be used to close the dialog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `Button` component to support custom icons on either side.
	- Introduced a new `DialogTitle` component for customizable dialog titles with optional icons and close functionality.
	- Added new storybook entries to demonstrate the capabilities of the `Button` and `DialogTitle` components.

- **Bug Fixes**
	- Improved button interaction in storybook by replacing old event handling with more robust asynchronous actions.

- **Refactor**
	- Removed unnecessary wrappers in the `Button` component to streamline the code.

- **Documentation**
	- Updated storybook documentation to reflect new features and usage examples for components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->