### PR TITLE
Add Breadcrumbs and BreadcrumbsItem components

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,0 +1,39 @@
+import { BreadcrumbsItem, Text } from "@components";
+import type { Breadcrumb } from "@utils";
+import { type ComponentProps, Fragment, forwardRef } from "react";
+
+type BreadcrumbsProps = {
+	breadcrumbs: Breadcrumb[];
+	onItemSelect: (id: string) => void;
+	separator?: string;
+};
+
+const Breadcrumbs = forwardRef<
+	HTMLMenuElement,
+	BreadcrumbsProps & ComponentProps<"nav">
+>(({ breadcrumbs, onItemSelect, separator = "/", ...props }, ref) => (
+	<nav ref={ref} {...props}>
+		{breadcrumbs.map((item, index) => (
+			<Fragment key={item.id}>
+				<BreadcrumbsItem
+					{...item}
+					onClick={() => onItemSelect(item.id)}
+					active={index === breadcrumbs.length - 1}
+				/>
+				{index < breadcrumbs.length - 1 && separator && (
+					<Text
+						as="span"
+						size={14}
+						className="text-black-40"
+						aria-hidden="true"
+					>
+						{separator}
+					</Text>
+				)}
+			</Fragment>
+		))}
+	</nav>
+));
+
+Breadcrumbs.displayName = "Breadcrumbs";
+export { Breadcrumbs };

--- a/src/components/Breadcrumbs/BreadcrumbsItem.tsx
+++ b/src/components/Breadcrumbs/BreadcrumbsItem.tsx
@@ -1,0 +1,26 @@
+import { Button } from "@components";
+import type { Breadcrumb } from "@utils";
+import { type ComponentProps, forwardRef } from "react";
+
+type BreadcrumbsItemProps = Breadcrumb &
+	ComponentProps<"button"> & {
+		active?: boolean;
+	};
+
+const BreadcrumbsItem = forwardRef<HTMLButtonElement, BreadcrumbsItemProps>(
+	({ active, id, label, ...props }, ref) => (
+		<Button
+			ref={ref}
+			aria-label={label}
+			id={id}
+			label={label}
+			size="sm"
+			className={!active ? "text-black-40" : ""}
+			variant="borderless"
+			{...props}
+		/>
+	),
+);
+
+BreadcrumbsItem.displayName = "BreadcrumbsItem";
+export { BreadcrumbsItem };

--- a/src/components/Breadcrumbs/index.ts
+++ b/src/components/Breadcrumbs/index.ts
@@ -1,0 +1,2 @@
+export * from "./Breadcrumbs";
+export * from "./BreadcrumbsItem";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,5 +1,6 @@
 export * from "./Avatar";
 export * from "./Badge";
+export * from "./Breadcrumbs";
 export * from "./Button";
 export * from "./Card";
 export * from "./Dialog";

--- a/src/stories/Breadcrumbs/Breadcrumbs.stories.ts
+++ b/src/stories/Breadcrumbs/Breadcrumbs.stories.ts
@@ -1,0 +1,37 @@
+import { Breadcrumbs } from "@components";
+import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "@storybook/test";
+import type { Breadcrumb } from "@utils";
+
+const testBreadcrumbs: Breadcrumb[] = [
+	{ label: "Home", id: "home" },
+	{ label: "Products", id: "products" },
+	{ label: "Product 1", id: "product-1" },
+];
+const testOnItemSelect = fn();
+
+const meta = {
+	title: "Base Components/Breadcrumbs/Breadcrumbs",
+	component: Breadcrumbs,
+	parameters: {
+		// Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
+		layout: "centered",
+		controls: {
+			exclude: ["children"],
+		},
+	},
+	// This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+	tags: ["autodocs"],
+	// More on argTypes: https://storybook.js.org/docs/api/argtypes
+	argTypes: {},
+	// Use `fn` to spy on the onClick arg, which will appear in the actions panel once invoked: https://storybook.js.org/docs/essentials/actions#action-args
+	args: {
+		breadcrumbs: testBreadcrumbs,
+		onItemSelect: testOnItemSelect,
+	},
+} satisfies Meta<typeof Breadcrumbs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const BasicBreadcrumbs: Story = {};

--- a/src/stories/Breadcrumbs/Breadcrumbs.stories.ts
+++ b/src/stories/Breadcrumbs/Breadcrumbs.stories.ts
@@ -1,6 +1,6 @@
 import { Breadcrumbs } from "@components";
 import type { Meta, StoryObj } from "@storybook/react";
-import { fn } from "@storybook/test";
+import { expect, fn, userEvent, within } from "@storybook/test";
 import type { Breadcrumb } from "@utils";
 
 const testBreadcrumbs: Breadcrumb[] = [
@@ -34,4 +34,36 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const BasicBreadcrumbs: Story = {};
+export const BasicBreadcrumbs: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const breadcrumbs = canvas.getByRole("navigation");
+		const breadcrumbItems = canvas.getAllByRole("button");
+
+		expect(breadcrumbs).toBeInTheDocument();
+		expect(breadcrumbItems).toHaveLength(testBreadcrumbs.length);
+
+		breadcrumbItems.forEach((breadcrumbItem, index) => {
+			expect(breadcrumbItem).toHaveTextContent(testBreadcrumbs[index].label);
+		});
+
+		await userEvent.click(breadcrumbItems[0]);
+
+		expect(testOnItemSelect).toHaveBeenCalledWith("home");
+	},
+};
+
+export const BreadcrumbsWithCustomSeparator: Story = {
+	args: {
+		separator: " > ",
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const breadcrumbs = canvas.getByRole("navigation");
+		const breadcrumbItems = canvas.getAllByRole("button");
+
+		expect(breadcrumbs).toBeInTheDocument();
+		expect(breadcrumbs).toHaveTextContent("Home > Products > Product 1");
+		expect(breadcrumbItems).toHaveLength(testBreadcrumbs.length);
+	},
+};

--- a/src/stories/Breadcrumbs/BreadcrumbsItem.stories.ts
+++ b/src/stories/Breadcrumbs/BreadcrumbsItem.stories.ts
@@ -1,0 +1,36 @@
+import { BreadcrumbsItem } from "@components";
+import { testText } from "@mocks";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta = {
+	title: "Base Components/Breadcrumbs/Breadcrumbs Item",
+	component: BreadcrumbsItem,
+	parameters: {
+		// Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
+		layout: "centered",
+		controls: {
+			exclude: ["children"],
+		},
+	},
+	// This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+	tags: ["autodocs"],
+	// More on argTypes: https://storybook.js.org/docs/api/argtypes
+	argTypes: {},
+	// Use `fn` to spy on the onClick arg, which will appear in the actions panel once invoked: https://storybook.js.org/docs/essentials/actions#action-args
+	args: {
+		label: testText,
+		id: "home",
+		active: false,
+	},
+} satisfies Meta<typeof BreadcrumbsItem>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const BasicBreadcrumbsItem: Story = {};
+
+export const ActiveBreadcrumbsItem: Story = {
+	args: {
+		active: true,
+	},
+};

--- a/src/stories/Breadcrumbs/BreadcrumbsItem.stories.ts
+++ b/src/stories/Breadcrumbs/BreadcrumbsItem.stories.ts
@@ -1,6 +1,7 @@
 import { BreadcrumbsItem } from "@components";
 import { testText } from "@mocks";
 import type { Meta, StoryObj } from "@storybook/react";
+import { expect, within } from "@storybook/test";
 
 const meta = {
 	title: "Base Components/Breadcrumbs/Breadcrumbs Item",
@@ -27,10 +28,27 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const BasicBreadcrumbsItem: Story = {};
+export const BasicBreadcrumbsItem: Story = {
+	play: ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const breadcrumbsItem = canvas.getByRole("button");
+
+		expect(breadcrumbsItem).toBeInTheDocument();
+		expect(breadcrumbsItem).toHaveTextContent(testText);
+		expect(breadcrumbsItem).toHaveClass("text-black-40");
+	},
+};
 
 export const ActiveBreadcrumbsItem: Story = {
 	args: {
 		active: true,
+	},
+	play: ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const breadcrumbsItem = canvas.getByRole("button");
+
+		expect(breadcrumbsItem).toBeInTheDocument();
+		expect(breadcrumbsItem).toHaveTextContent(testText);
+		expect(breadcrumbsItem).toHaveClass("text-black-100");
 	},
 };

--- a/src/utils/types/index.ts
+++ b/src/utils/types/index.ts
@@ -32,3 +32,9 @@ export type CustomIcon = ForwardRefExoticComponent<
 export type ButtonVariant = "borderless" | "gray" | "outline" | "filled";
 
 export type SeparatorDirection = "horizontal" | "vertical";
+
+export type Breadcrumb = {
+	label: string;
+	id: string;
+	disabled?: boolean;
+};


### PR DESCRIPTION
This pull request adds the Breadcrumbs and BreadcrumbsItem components to the project. These components are used for displaying breadcrumb navigation. The Breadcrumbs component is a navigation menu that displays a list of breadcrumbs, while the BreadcrumbsItem component represents an individual breadcrumb item. These components can be used to enhance the navigation experience in the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced a `Breadcrumbs` component for enhanced navigation, allowing users to see and interact with their navigation history through clickable breadcrumb items.
  - Added `BreadcrumbsItem` component to represent individual navigational elements within the `Breadcrumbs` component.
  - Deployed Storybook stories for `Breadcrumbs` and `BreadcrumbsItem` to demonstrate component functionality and states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->