### PR TITLE
Refactor import paths for icons

### DIFF
--- a/src/components/Icons/ssr/AI.tsx
+++ b/src/components/Icons/ssr/AI.tsx
@@ -1,6 +1,7 @@
-import { AIWeights, CustomIconBase } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { AIWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const AIIcon = forwardRef<SVGSVGElement, CustomIconProps>((props, ref) => (
 	<CustomIconBase ref={ref} {...props} weights={AIWeights} />

--- a/src/components/Icons/ssr/Add.tsx
+++ b/src/components/Icons/ssr/Add.tsx
@@ -1,6 +1,7 @@
-import { AddWeights, CustomIconBase } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { AddWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const AddIcon = forwardRef<SVGSVGElement, CustomIconProps>((props, ref) => (
 	<CustomIconBase ref={ref} {...props} weights={AddWeights} />

--- a/src/components/Icons/ssr/ArrowFall.tsx
+++ b/src/components/Icons/ssr/ArrowFall.tsx
@@ -1,6 +1,7 @@
-import { ArrowFallWeights, CustomIconBase } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { ArrowFallWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const ArrowFallIcon = forwardRef<SVGSVGElement, CustomIconProps>(
 	(props, ref) => (

--- a/src/components/Icons/ssr/ArrowLineDown.tsx
+++ b/src/components/Icons/ssr/ArrowLineDown.tsx
@@ -1,6 +1,7 @@
-import { ArrowLineDownWeights, CustomIconBase } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { ArrowLineDownWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const ArrowLineDownIcon = forwardRef<SVGSVGElement, CustomIconProps>(
 	(props, ref) => (

--- a/src/components/Icons/ssr/ArrowLineLeft.tsx
+++ b/src/components/Icons/ssr/ArrowLineLeft.tsx
@@ -1,6 +1,7 @@
-import { ArrowLineLeftWeights, CustomIconBase } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { ArrowLineLeftWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const ArrowLineLeftIcon = forwardRef<SVGSVGElement, CustomIconProps>(
 	(props, ref) => (

--- a/src/components/Icons/ssr/ArrowLineRight.tsx
+++ b/src/components/Icons/ssr/ArrowLineRight.tsx
@@ -1,6 +1,7 @@
-import { ArrowLineRightWeights, CustomIconBase } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { ArrowLineRightWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const ArrowLineRightIcon = forwardRef<SVGSVGElement, CustomIconProps>(
 	(props, ref) => (

--- a/src/components/Icons/ssr/ArrowLineUp.tsx
+++ b/src/components/Icons/ssr/ArrowLineUp.tsx
@@ -1,6 +1,7 @@
-import { ArrowLineUpWeights, CustomIconBase } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { ArrowLineUpWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const ArrowLineUpIcon = forwardRef<SVGSVGElement, CustomIconProps>(
 	(props, ref) => (

--- a/src/components/Icons/ssr/ArrowLineUpDown.tsx
+++ b/src/components/Icons/ssr/ArrowLineUpDown.tsx
@@ -1,6 +1,7 @@
-import { ArrowLineUpDownWeights, CustomIconBase } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { ArrowLineUpDownWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const ArrowLineUpDownIcon = forwardRef<SVGSVGElement, CustomIconProps>(
 	(props, ref) => (

--- a/src/components/Icons/ssr/ArrowRight.tsx
+++ b/src/components/Icons/ssr/ArrowRight.tsx
@@ -1,6 +1,7 @@
-import { ArrowRightWeights, CustomIconBase } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { ArrowRightWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const ArrowRightIcon = forwardRef<SVGSVGElement, CustomIconProps>(
 	(props, ref) => (

--- a/src/components/Icons/ssr/ArrowRise.tsx
+++ b/src/components/Icons/ssr/ArrowRise.tsx
@@ -1,6 +1,7 @@
-import { ArrowRiseWeights, CustomIconBase } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { ArrowRiseWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const ArrowRiseIcon = forwardRef<SVGSVGElement, CustomIconProps>(
 	(props, ref) => (

--- a/src/components/Icons/ssr/ArrowsDown.tsx
+++ b/src/components/Icons/ssr/ArrowsDown.tsx
@@ -1,6 +1,7 @@
-import { ArrowsDownWeights, CustomIconBase } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { ArrowsDownWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const ArrowsDownIcon = forwardRef<SVGSVGElement, CustomIconProps>(
 	(props, ref) => (

--- a/src/components/Icons/ssr/ArrowsDownUp.tsx
+++ b/src/components/Icons/ssr/ArrowsDownUp.tsx
@@ -1,6 +1,7 @@
-import { ArrowsDownUpWeights, CustomIconBase } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { ArrowsDownUpWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const ArrowsDownUpIcon = forwardRef<SVGSVGElement, CustomIconProps>(
 	(props, ref) => (

--- a/src/components/Icons/ssr/ArrowsUp.tsx
+++ b/src/components/Icons/ssr/ArrowsUp.tsx
@@ -1,6 +1,7 @@
-import { ArrowsUpWeights, CustomIconBase } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { ArrowsUpWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const ArrowsUpIcon = forwardRef<SVGSVGElement, CustomIconProps>(
 	(props, ref) => (

--- a/src/components/Icons/ssr/Clipboard.tsx
+++ b/src/components/Icons/ssr/Clipboard.tsx
@@ -1,6 +1,7 @@
-import { ClipboardWeights, CustomIconBase } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { ClipboardWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const ClipboardIcon = forwardRef<SVGSVGElement, CustomIconProps>(
 	(props, ref) => (

--- a/src/components/Icons/ssr/Close.tsx
+++ b/src/components/Icons/ssr/Close.tsx
@@ -1,6 +1,7 @@
-import { CloseWeights, CustomIconBase } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { CloseWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const CloseIcon = forwardRef<SVGSVGElement, CustomIconProps>((props, ref) => (
 	<CustomIconBase ref={ref} {...props} weights={CloseWeights} />

--- a/src/components/Icons/ssr/Copy.tsx
+++ b/src/components/Icons/ssr/Copy.tsx
@@ -1,6 +1,7 @@
-import { CopyWeights, CustomIconBase } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { CopyWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const CopyIcon = forwardRef<SVGSVGElement, CustomIconProps>((props, ref) => (
 	<CustomIconBase ref={ref} {...props} weights={CopyWeights} />

--- a/src/components/Icons/ssr/DefaultIcon.tsx
+++ b/src/components/Icons/ssr/DefaultIcon.tsx
@@ -1,6 +1,7 @@
-import { CustomIconBase, DefaultIconWeights } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { DefaultIconWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const DefaultIcon = forwardRef<SVGSVGElement, CustomIconProps>((props, ref) => (
 	<CustomIconBase ref={ref} {...props} weights={DefaultIconWeights} />

--- a/src/components/Icons/ssr/DocX.tsx
+++ b/src/components/Icons/ssr/DocX.tsx
@@ -1,6 +1,7 @@
-import { CustomIconBase, DocXWeights } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { DocXWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const DocXIcon = forwardRef<SVGSVGElement, CustomIconProps>((props, ref) => (
 	<CustomIconBase ref={ref} {...props} weights={DocXWeights} />

--- a/src/components/Icons/ssr/Dot.tsx
+++ b/src/components/Icons/ssr/Dot.tsx
@@ -1,6 +1,7 @@
-import { CustomIconBase, DotWeights } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { DotWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const DotIcon = forwardRef<SVGSVGElement, CustomIconProps>((props, ref) => (
 	<CustomIconBase ref={ref} {...props} weights={DotWeights} />

--- a/src/components/Icons/ssr/DotsThreeOutlineHorizontal.tsx
+++ b/src/components/Icons/ssr/DotsThreeOutlineHorizontal.tsx
@@ -1,6 +1,7 @@
-import { CustomIconBase, DotsThreeOutlineHorizontalWeights } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { DotsThreeOutlineHorizontalWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const DotsThreeOutlineHorizontalIcon = forwardRef<
 	SVGSVGElement,

--- a/src/components/Icons/ssr/Explain.tsx
+++ b/src/components/Icons/ssr/Explain.tsx
@@ -1,6 +1,7 @@
-import { CustomIconBase, ExplainWeights } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { ExplainWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const ExplainIcon = forwardRef<SVGSVGElement, CustomIconProps>((props, ref) => (
 	<CustomIconBase ref={ref} {...props} weights={ExplainWeights} />

--- a/src/components/Icons/ssr/Form.tsx
+++ b/src/components/Icons/ssr/Form.tsx
@@ -1,6 +1,7 @@
-import { CustomIconBase, FormWeights } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { FormWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const FormIcon = forwardRef<SVGSVGElement, CustomIconProps>((props, ref) => (
 	<CustomIconBase ref={ref} {...props} weights={FormWeights} />

--- a/src/components/Icons/ssr/FourLeafClover.tsx
+++ b/src/components/Icons/ssr/FourLeafClover.tsx
@@ -1,6 +1,7 @@
-import { CustomIconBase, FourLeafCloverWeights } from "@components";
 import type { CustomIcon } from "@types";
 import { forwardRef } from "react";
+import { FourLeafCloverWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const FourLeafCloverIcon: CustomIcon = forwardRef((props, ref) => (
 	<CustomIconBase ref={ref} {...props} weights={FourLeafCloverWeights} />

--- a/src/components/Icons/ssr/FourPointedStar.tsx
+++ b/src/components/Icons/ssr/FourPointedStar.tsx
@@ -1,6 +1,7 @@
-import { CustomIconBase, FourPointedStarWeights } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { FourPointedStarWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const FourPointedStarIcon = forwardRef<SVGSVGElement, CustomIconProps>(
 	(props, ref) => (

--- a/src/components/Icons/ssr/Goto.tsx
+++ b/src/components/Icons/ssr/Goto.tsx
@@ -1,6 +1,7 @@
-import { CustomIconBase, GotoWeights } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { GotoWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const GotoIcon = forwardRef<SVGSVGElement, CustomIconProps>((props, ref) => (
 	<CustomIconBase ref={ref} {...props} weights={GotoWeights} />

--- a/src/components/Icons/ssr/Help.tsx
+++ b/src/components/Icons/ssr/Help.tsx
@@ -1,6 +1,7 @@
-import { CustomIconBase, HelpWeights } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { HelpWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const HelpIcon = forwardRef<SVGSVGElement, CustomIconProps>((props, ref) => (
 	<CustomIconBase ref={ref} {...props} weights={HelpWeights} />

--- a/src/components/Icons/ssr/HorizontalScreen.tsx
+++ b/src/components/Icons/ssr/HorizontalScreen.tsx
@@ -1,6 +1,7 @@
-import { CustomIconBase, HorizontalScreenWeights } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { HorizontalScreenWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const HorizontalScreenIcon = forwardRef<SVGSVGElement, CustomIconProps>(
 	(props, ref) => (

--- a/src/components/Icons/ssr/Line.tsx
+++ b/src/components/Icons/ssr/Line.tsx
@@ -1,6 +1,7 @@
-import { CustomIconBase, LineWeights } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { LineWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const LineIcon = forwardRef<SVGSVGElement, CustomIconProps>((props, ref) => (
 	<CustomIconBase ref={ref} {...props} weights={LineWeights} />

--- a/src/components/Icons/ssr/LoadingB.tsx
+++ b/src/components/Icons/ssr/LoadingB.tsx
@@ -1,7 +1,8 @@
-import { CustomIconBase, LoadingBWeights } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
 import { twMerge } from "tailwind-merge";
+import { LoadingBWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const LoadingBIcon = forwardRef<SVGSVGElement, CustomIconProps>(
 	(props, ref) => (

--- a/src/components/Icons/ssr/Maximize.tsx
+++ b/src/components/Icons/ssr/Maximize.tsx
@@ -1,6 +1,7 @@
-import { CustomIconBase, MaximizeWeights } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { MaximizeWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const MaximizeIcon = forwardRef<SVGSVGElement, CustomIconProps>(
 	(props, ref) => (

--- a/src/components/Icons/ssr/Minimize.tsx
+++ b/src/components/Icons/ssr/Minimize.tsx
@@ -1,6 +1,7 @@
-import { CustomIconBase, MinimizeWeights } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { MinimizeWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const MinimizeIcon = forwardRef<SVGSVGElement, CustomIconProps>(
 	(props, ref) => (

--- a/src/components/Icons/ssr/Notepad.tsx
+++ b/src/components/Icons/ssr/Notepad.tsx
@@ -1,6 +1,7 @@
-import { CustomIconBase, NotepadWeights } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { NotepadWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const NotepadIcon = forwardRef<SVGSVGElement, CustomIconProps>((props, ref) => (
 	<CustomIconBase ref={ref} {...props} weights={NotepadWeights} />

--- a/src/components/Icons/ssr/OneNote.tsx
+++ b/src/components/Icons/ssr/OneNote.tsx
@@ -1,6 +1,7 @@
-import { CustomIconBase, OneNoteWeights } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { OneNoteWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const OneNoteIcon = forwardRef<SVGSVGElement, CustomIconProps>((props, ref) => (
 	<CustomIconBase ref={ref} {...props} weights={OneNoteWeights} />

--- a/src/components/Icons/ssr/PPT.tsx
+++ b/src/components/Icons/ssr/PPT.tsx
@@ -1,6 +1,7 @@
-import { CustomIconBase, PPTWeights } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { PPTWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const PPTIcon = forwardRef<SVGSVGElement, CustomIconProps>((props, ref) => (
 	<CustomIconBase ref={ref} {...props} weights={PPTWeights} />

--- a/src/components/Icons/ssr/Rectangle.tsx
+++ b/src/components/Icons/ssr/Rectangle.tsx
@@ -1,6 +1,7 @@
-import { CustomIconBase, RectangleWeights } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { RectangleWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const RectangleIcon = forwardRef<SVGSVGElement, CustomIconProps>(
 	(props, ref) => (

--- a/src/components/Icons/ssr/Rightbar.tsx
+++ b/src/components/Icons/ssr/Rightbar.tsx
@@ -1,6 +1,7 @@
-import { CustomIconBase, RightbarWeights } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { RightbarWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const RightbarIcon = forwardRef<SVGSVGElement, CustomIconProps>(
 	(props, ref) => (

--- a/src/components/Icons/ssr/RoundedCorner.tsx
+++ b/src/components/Icons/ssr/RoundedCorner.tsx
@@ -1,6 +1,7 @@
-import { CustomIconBase, RoundedCornerWeights } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { RoundedCornerWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const RoundedCornerIcon = forwardRef<SVGSVGElement, CustomIconProps>(
 	(props, ref) => (

--- a/src/components/Icons/ssr/Search.tsx
+++ b/src/components/Icons/ssr/Search.tsx
@@ -1,6 +1,7 @@
-import { CustomIconBase, SearchWeights } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { SearchWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const SearchIcon = forwardRef<SVGSVGElement, CustomIconProps>((props, ref) => (
 	<CustomIconBase ref={ref} {...props} weights={SearchWeights} />

--- a/src/components/Icons/ssr/SnowUI.tsx
+++ b/src/components/Icons/ssr/SnowUI.tsx
@@ -1,6 +1,7 @@
-import { CustomIconBase, SnowUIWeights } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { SnowUIWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const SnowUIIcon = forwardRef<SVGSVGElement, CustomIconProps>((props, ref) => (
 	<CustomIconBase ref={ref} {...props} weights={SnowUIWeights} />

--- a/src/components/Icons/ssr/Star.tsx
+++ b/src/components/Icons/ssr/Star.tsx
@@ -1,6 +1,7 @@
-import { CustomIconBase, StarWeights } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { StarWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const StarIcon = forwardRef<SVGSVGElement, CustomIconProps>((props, ref) => (
 	<CustomIconBase ref={ref} {...props} weights={StarWeights} />

--- a/src/components/Icons/ssr/StatusIcon.tsx
+++ b/src/components/Icons/ssr/StatusIcon.tsx
@@ -1,8 +1,8 @@
-import { LoadingBIcon } from "@components";
 import { STATUSES } from "@constants";
 import { Check, Warning } from "@phosphor-icons/react/dist/ssr";
 import type { Status } from "@types";
 import { twMerge } from "tailwind-merge";
+import { LoadingBIcon } from "./LoadingB";
 
 const StatusIcon = ({
 	status,

--- a/src/components/Icons/ssr/Stop.tsx
+++ b/src/components/Icons/ssr/Stop.tsx
@@ -1,6 +1,7 @@
-import { CustomIconBase, StopWeights } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { StopWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const StopIcon = forwardRef<SVGSVGElement, CustomIconProps>((props, ref) => (
 	<CustomIconBase ref={ref} {...props} weights={StopWeights} />

--- a/src/components/Icons/ssr/TXT.tsx
+++ b/src/components/Icons/ssr/TXT.tsx
@@ -1,6 +1,7 @@
-import { CustomIconBase, TXTWeights } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { TXTWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const TXTIcon = forwardRef<SVGSVGElement, CustomIconProps>((props, ref) => (
 	<CustomIconBase ref={ref} {...props} weights={TXTWeights} />

--- a/src/components/Icons/ssr/TextA.tsx
+++ b/src/components/Icons/ssr/TextA.tsx
@@ -1,6 +1,7 @@
-import { CustomIconBase, TextAWeights } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { TextAWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const TextAIcon = forwardRef<SVGSVGElement, CustomIconProps>((props, ref) => (
 	<CustomIconBase ref={ref} {...props} weights={TextAWeights} />

--- a/src/components/Icons/ssr/Variables.tsx
+++ b/src/components/Icons/ssr/Variables.tsx
@@ -1,6 +1,7 @@
-import { CustomIconBase, VariablesWeights } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { VariablesWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const VariablesIcon = forwardRef<SVGSVGElement, CustomIconProps>(
 	(props, ref) => (

--- a/src/components/Icons/ssr/VerticalScreen.tsx
+++ b/src/components/Icons/ssr/VerticalScreen.tsx
@@ -1,6 +1,7 @@
-import { CustomIconBase, VerticalScreenWeights } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { VerticalScreenWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const VerticalScreenIcon = forwardRef<SVGSVGElement, CustomIconProps>(
 	(props, ref) => (

--- a/src/components/Icons/ssr/Windowed.tsx
+++ b/src/components/Icons/ssr/Windowed.tsx
@@ -1,6 +1,7 @@
-import { CustomIconBase, WindowedWeights } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { WindowedWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const WindowedIcon = forwardRef<SVGSVGElement, CustomIconProps>(
 	(props, ref) => (

--- a/src/components/Icons/ssr/XCircle.tsx
+++ b/src/components/Icons/ssr/XCircle.tsx
@@ -1,6 +1,7 @@
-import { CustomIconBase, XCircleWeights } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { XCircleWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const XCircleIcon = forwardRef<SVGSVGElement, CustomIconProps>((props, ref) => (
 	<CustomIconBase ref={ref} {...props} weights={XCircleWeights} />

--- a/src/components/Icons/ssr/XLSX.tsx
+++ b/src/components/Icons/ssr/XLSX.tsx
@@ -1,6 +1,7 @@
-import { CustomIconBase, XLSXWeights } from "@components";
 import type { CustomIconProps } from "@types";
 import { forwardRef } from "react";
+import { XLSXWeights } from "../defs";
+import { CustomIconBase } from "../lib";
 
 const XLSXIcon = forwardRef<SVGSVGElement, CustomIconProps>((props, ref) => (
 	<CustomIconBase ref={ref} {...props} weights={XLSXWeights} />


### PR DESCRIPTION
This pull request refactors the import paths for the icons to avoid circular dependencies. The import paths have been updated in multiple files to ensure proper module resolution. This change improves the maintainability and organization of the codebase.