### PR TITLE
fix: specify push target for git command in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Bump lib version
         run: |
           npm version --allow-same-version=true ${{ github.event.release.tag_name }}
-          if ! git push; then
+          if ! git push origin HEAD:main; then
             echo "Ошибка при выполнении git push"
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,15 +37,14 @@ jobs:
 
       - name: Bump lib version
         run: |
-          npm version --allow-same-version=true ${{ github.event.release.tag_name }}
-          if ! git push origin HEAD:main; then
-            echo "Ошибка при выполнении git push"
-            exit 1
-          fi
+          npm version --allow-same-version=true -m "chore: bump version to %s" ${{ github.event.release.tag_name }}
+
+      - name: Push new version
+        run: git push origin HEAD:main
 
       - name: Build
         run: bun run build
 
-      - run: npm publish
+      - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Улучшения CI/CD**
	- Обновлен рабочий процесс GitHub Actions для публикации пакета Node.js.
	- Уточнена команда push для явного указания целевой ветки при обновлении версии библиотеки.
	- Добавлен флаг `--access public` для команды публикации пакета, обеспечивающий публичный доступ.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->